### PR TITLE
Update Hapi version for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "chai": "^3.4.1",
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^7.0.0",
-    "hapi": "^14.0.0",
+    "hapi": "^15.2.0",
     "mocha": "^3.0.1",
-    "sinon": "^1.17.2"
+    "timekeeper": "^1.0.0"
   },
   "dependencies": {
     "es-hash": "^1.0.4",

--- a/test/routebox.test.js
+++ b/test/routebox.test.js
@@ -1,6 +1,6 @@
 const Hapi = require('hapi');
 const expect = require('chai').expect;
-const sinon = require('sinon');
+const Timekeeper = require('timekeeper');
 
 function assertCached(res) {
     expect(res.headers['x-was-cached']).to.exist;
@@ -13,20 +13,21 @@ function assertNotCached(res) {
 
 describe('routebox', function () {
     var server;
-    var clock;
     beforeEach(function (done) {
-        clock = sinon.useFakeTimers();
         server = new Hapi.Server();
         server.connection();
         server.register(require('../'), (err) => {
             expect(err).to.not.exist;
-            server.start(done);
+
+            server.start((err) => {
+              expect(err).to.not.exist;
+              done();
+            });
         });
     });
 
     afterEach(function (done) {
         server.stop(done);
-        clock.restore();
     });
 
     it('caches responses', function (done) {
@@ -67,7 +68,7 @@ describe('routebox', function () {
             expect(res.result).to.equal(0);
             expect(res.statusCode).to.equal(200);
             assertNotCached(res);
-            clock.tick(1001);
+            Timekeeper.travel(Date.now() + 1001);
 
             server.inject({ method: 'GET', url: '/a' }, (res2) => {
                 expect(res2.result).to.equal(1);


### PR DESCRIPTION
I was running into some issues with creating new tests because the version of Hapi is out-of-date. I updated the version of Hapi to 15.2.0.

Had to remove `sinon.useFakeTimers()` because for some reason causes the server to not start. I replaced it with [timekeeper](https://github.com/vesln/timekeeper) to move the clock ahead to test TTL.